### PR TITLE
chore(ci): pin wasm-opt version and cache the binary

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -22,7 +22,9 @@ runs:
           ~/.rustup
           ~/.cargo
           target/
-        key: v4::rust-toolchain::${{ runner.os }}::${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', '.github/actions/setup/action.yml') }}::${{ inputs.wasm-opt }}
+        key: v5::rust-toolchain::${{ runner.os }}::${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml', '.github/actions/setup/action.yml') }}
+        # partial restore for quicker rebuilds on cache miss
+        restore-keys: v5::rust-toolchain::${{ runner.os }}
 
     - name: install rust toolchain
       if: steps.toolchain-cache.outputs.cache-hit != 'true'
@@ -30,8 +32,36 @@ runs:
       run: |
         rustup update
 
-    - name: build wasm-opt
-      if: steps.toolchain-cache.outputs.cache-hit != 'true' && inputs.wasm-opt == 'true'
+    - name: extract wasm-opt version
+      id: wasm-opt-version
+      if: inputs.wasm-opt == 'true'
       shell: bash
       run: |
-        cargo install wasm-opt
+        version=$(
+          cargo metadata --format-version 1 \
+            | jq -r \
+              '.packages[]
+              | select(.name == "datakit")
+              | .metadata["wasm-opt"].version
+            '
+        )
+        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "WASM_OPT_VERSION=$version" >> $GITHUB_ENV
+
+    - name: restore cached wasm-opt
+      uses: actions/cache@v4
+      id: wasm-opt-cache
+      if: inputs.wasm-opt == 'true'
+      with:
+        path: ~/.cargo/bin/wasm-opt
+        key: v1::wasm-opt::${{ env.WASM_OPT_VERSION }}::${{ runner.os }}
+
+    - name: install wasm-opt
+      if: inputs.wasm-opt == 'true' && steps.wasm-opt-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo install wasm-opt@"$WASM_OPT_VERSION"
+
+    - name: wasm-opt --version
+      if: inputs.wasm-opt == 'true'
+      shell: bash
+      run: wasm-opt --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,8 @@ form_urlencoded = "1.2.1"
 
 [dev-dependencies]
 mock_proxy_wasm = { path = "crates/mock_proxy_wasm" }
+
+[package.metadata.wasm-opt]
+# https://github.com/brson/wasm-opt-rs/releases/tag/v0.116.1
+# released 2024-03-31
+version = "0.116.1"


### PR DESCRIPTION
* use a separate cache for the `wasm-opt` binary so that our toolchain/build cache isn't partitioned across `inputs.wasm-opt`
* add `restore-keys` to the toolchain cache step for partial restore